### PR TITLE
I have added remember me features that handles both regular login and social login at a time.

### DIFF
--- a/sign-in/spring-mvc-normal/src/main/java/net/petrikainulainen/spring/social/signinmvc/security/service/CustomPersistentTokenBasedRememberMeServices.java
+++ b/sign-in/spring-mvc-normal/src/main/java/net/petrikainulainen/spring/social/signinmvc/security/service/CustomPersistentTokenBasedRememberMeServices.java
@@ -1,0 +1,39 @@
+package net.petrikainulainen.spring.social.signinmvc.security.service;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.rememberme.PersistentTokenBasedRememberMeServices;
+import org.springframework.security.web.authentication.rememberme.PersistentTokenRepository;
+
+/**
+ * This class handles rememberMeRequested decision only.
+ * This rememberMeRequested returns original results for regular(id/password) login but returns always 'true' for social login.
+ * @author Hosang Jeon
+ */
+public class CustomPersistentTokenBasedRememberMeServices extends
+		PersistentTokenBasedRememberMeServices {
+
+	public CustomPersistentTokenBasedRememberMeServices(String key,
+			UserDetailsService userDetailsService,
+			PersistentTokenRepository tokenRepository) {
+		super(key, userDetailsService, tokenRepository);
+	}
+
+	@Override
+	protected boolean rememberMeRequested(HttpServletRequest request,
+			String parameter) {
+		
+		String isRegularLogin = request.getParameter("isRegularLogin");
+
+				// Regular Login
+        if (isRegularLogin != null && "true".equals(isRegularLogin)) {
+        	return super.rememberMeRequested(request, parameter);
+        }
+        // Social Login 
+        else{
+        	// returns always 'true' for social login.
+        	return true;
+        }
+	}
+}

--- a/sign-in/spring-mvc-normal/src/main/resources/exampleApplicationContext-security.xml
+++ b/sign-in/spring-mvc-normal/src/main/resources/exampleApplicationContext-security.xml
@@ -33,6 +33,9 @@
 
         <!-- The rest of our application is protected. -->
         <security:intercept-url pattern="/**" access="hasRole('ROLE_USER')"/>
+        
+        <!-- Enable Remember Me Services -->
+        <security:remember-me key="myRememberMeKey" services-ref="customPersistentTokenBasedRememberMeServices" />
 
         <!-- Adds social authentication filter to the Spring Security filter chain. -->
         <security:custom-filter ref="socialAuthenticationFilter" before="PRE_AUTH_FILTER" />
@@ -67,7 +70,30 @@
 
         <!-- Sets the url of the registration form. -->
         <property name="signupUrl" value="/user/register"/>
+        <!-- Define remember-me services for social authentication filter -->
+        <property name="rememberMeServices" ref="customPersistentTokenBasedRememberMeServices" />
     </bean>
+    
+    <!--
+        Configures the custom persistent token-based remember me service which handles persistent remember
+        using browser cookie for both regular login and social login.
+    -->
+    <bean id="customPersistentTokenBasedRememberMeServices" class="net.petrikainulainen.spring.social.signinmvc.security.service.CustomPersistentTokenBasedRememberMeServices">
+    	<constructor-arg value="myRememberMeKey"/>
+    	<constructor-arg ref="userDetailsService"/>
+    	<constructor-arg ref="tokenRepository"/>
+        <property name="parameter" value="rememberme"/>
+        <property name="tokenValiditySeconds" value="1209600"/>
+    </bean>
+    
+    <!--
+        Configures the JDBC token repository for remember me services.
+    -->
+    <bean id="tokenRepository"
+		class="org.springframework.security.web.authentication.rememberme.JdbcTokenRepositoryImpl">
+		<property name="createTableOnStartup" value="false" />
+		<property name="dataSource" ref="dataSource" />
+	</bean>
 
     <!--
         Configures the social authentication provider which processes authentication requests

--- a/sign-in/spring-mvc-normal/src/main/webapp/WEB-INF/jsp/user/login.jsp
+++ b/sign-in/spring-mvc-normal/src/main/webapp/WEB-INF/jsp/user/login.jsp
@@ -24,6 +24,7 @@
             </c:if>
             <form action="/login/authenticate" method="POST" role="form">
                 <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
+                <input type="hidden" name="isRegularLogin" value="true" />
                 <div class="row">
                     <div id="form-group-email" class="form-group col-lg-4">
                         <label class="control-label" for="user-email"><spring:message code="label.user.email"/>:</label>
@@ -35,6 +36,11 @@
                     <div id="form-group-password" class="form-group col-lg-4">
                         <label class="control-label" for="user-password"><spring:message code="label.user.password"/>:</label>
                         <input id="user-password" name="password" type="password" class="form-control"/>
+                    </div>
+                </div>
+                <div class="row">
+                    <div id="form-group-rememberme" class="col-lg-4">
+                        <input type="checkbox" name="rememberme" value="true" checked="checked"> Remember me
                     </div>
                 </div>
                 <div class="row">


### PR DESCRIPTION
I've added just one class (net.petrikainulainen.spring.social.signinmvc.security.service.CustomPersistentTokenBasedRememberMeServices).
This class handles rememberMeRequested decision only.
The rememberMeRequested returns original results for regular(id/password) login but returns always 'true' for social login.

I have added one checkbox input for 'rememberme' and one hidden input for 'isRegularLogin' in the login.jsp file.
I also have added rememberMe configurations and beans for that in the SecurityContext.java file and exampleApplicationContext-security.xml file.

Please ensure that you have to create a table using the script below for the persistent login before running the application.

CREATE TABLE `persistent_logins` (
  `username` varchar(64) NOT NULL,
  `series` varchar(64) NOT NULL,
  `token` varchar(64) NOT NULL,
  `last_used` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
  PRIMARY KEY (`series`)
) ENGINE=InnoDB DEFAULT CHARSET=latin1;
